### PR TITLE
Feature/swift package manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,10 +3,10 @@ import PackageDescription
 
 let package = Package(
     name: "Gestalt",
-
-    dependencies: [
+    products: [
+        .library(name: "Gestalt", targets: [ "Gestalt" ])
     ],
-
+    dependencies: [],
     targets: [
         .target    (name         : "Gestalt", 
                     path         : "Gestalt"),

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:4.0
+import PackageDescription
+
+let package = Package(
+    name: "Gestalt",
+
+    dependencies: [
+    ],
+
+    targets: [
+        .target    (name         : "Gestalt", 
+                    path         : "Gestalt"),
+        .testTarget(name         : "GestaltTests", 
+                    dependencies : [ "Gestalt" ],
+                    path         : "GestaltTests")
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ or via [Cocoapods](https://cocoapods.org):
 
     pod 'Gestalt'
 
+or via [Swift Package Manager](https://swift.org):
+
+```swift
+let package = Package(
+    name: "GestaltDemo",
+    dependencies: [
+      .package(url: "https://github.com/regexident/Gestalt.git", from: "1.2.1")
+    ],
+    targets: [
+        .target(name: "GestaltDemo", dependencies: [ "Gestalt" ])
+    ]
+)
+```
+
 ## License
 
 **Gestalt** is available under the **MPL-2.0 license**. See the `LICENSE` file for more info.


### PR DESCRIPTION
Add support for Swift Package Manager. Builds and exports the "Gestalt" SPM library.

To actually use it, you need a UI/AppKit enabled SPM, like SwiftXcode.