### PR TITLE
Fix broken UITextEffectsWindow after theme change

### DIFF
--- a/Gestalt/ThemeManager.swift
+++ b/Gestalt/ThemeManager.swift
@@ -82,6 +82,17 @@ public class ThemeManager {
         }
     }
 
+    /// Defines a list of window class names to check for during the appearance hack.
+    /// If none are defined, then views from all windows will be removed and re-added.
+    ///
+    /// Example of using this property:
+    /// ThemeManager.default.allowedWindowClasses = [UIWindow.classForCoder(), CustomWindow.classForCoder()]
+    ///
+    /// - Note:
+    ///   If this property is not set, then you might run into problems regarding a broken
+    ///   `UITextEffectsWindow`, see https://github.com/regexident/Gestalt/issues/25
+    public var allowedWindowClasses: [AnyClass]?
+
     private var observations: Set<ObjectIdentifier> = []
 
     /// Creates a `ThemeManager` instance
@@ -257,7 +268,11 @@ public class ThemeManager {
             // HACK: apparently the only way to
             // change the appearance of existing instances:
             if let sharedApplication = self?.optionalSharedApplication {
+                let classNames: [String]? = self?.allowedWindowClasses?.map({ NSStringFromClass($0) })
+
                 for window in sharedApplication.windows {
+                    guard classNames?.contains(NSStringFromClass(window.classForCoder)) ?? true else { return }
+
                     for view in window.subviews {
                         view.removeFromSuperview()
                         window.addSubview(view)


### PR DESCRIPTION
This PR adds a new property to the `ThemeManager` that allows to set a list of window class names, which are then checked during the appearance hack.

This change fixes a problem where the appearance hack would change the views of the `UITextEffectsWindow`, which then leads to side-effects when a keyboard is shown.

These changes here are purely additive to not break any existing integrations.

The property will be set through the `ThemeManager` like follows

```swift
ThemeManager.default.allowedWindowClasses = [UIWindow.classForCoder()]
```

Closes #25 